### PR TITLE
Update google-protobuf so we can use Ruby 2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,42 @@
 PATH
   remote: .
   specs:
-    gcr (0.0.2)
-      google-protobuf (~> 3.3, >= 3.3.0)
+    gcr (0.0.4)
+      google-protobuf (~> 3.5, >= 3.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     diff-lcs (1.3)
-    faraday (0.12.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    google-protobuf (3.3.0)
-    googleauth (0.5.1)
-      faraday (~> 0.9)
-      jwt (~> 1.4)
+    google-protobuf (3.5.1.2)
+    googleapis-common-protos-types (1.0.1)
+      google-protobuf (~> 3.0)
+    googleauth (0.6.2)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
       logging (~> 2.0)
       memoist (~> 0.12)
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.2.5)
+    grpc (1.10.0)
       google-protobuf (~> 3.1)
-      googleauth (~> 0.5.1)
-    jwt (1.5.6)
+      googleapis-common-protos-types (~> 1.0.0)
+      googleauth (>= 0.5.1, < 0.7)
+    jwt (2.1.0)
     little-plugger (1.1.4)
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    memoist (0.15.0)
-    multi_json (1.12.1)
+    memoist (0.16.0)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     os (0.9.6)
-    public_suffix (2.0.5)
+    public_suffix (3.0.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -47,10 +50,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    signet (0.7.3)
+    signet (0.8.1)
       addressable (~> 2.3)
       faraday (~> 0.9)
-      jwt (~> 1.5)
+      jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
 
 PLATFORMS
@@ -58,8 +61,8 @@ PLATFORMS
 
 DEPENDENCIES
   gcr!
-  grpc (~> 1.2, >= 1.2.5)
+  grpc (~> 1.10, >= 1.2.5)
   rspec (~> 3.5, >= 3.5.0)
 
 BUNDLED WITH
-   1.14.4
+   1.16.1

--- a/gcr.gemspec
+++ b/gcr.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mastahyeti/gcr"
   s.licenses = ['MIT']
 
-  s.add_runtime_dependency 'google-protobuf', '~> 3.3', '>= 3.3.0'
+  s.add_runtime_dependency 'google-protobuf', '~> 3.5', '>= 3.3.0'
 
-  s.add_development_dependency 'grpc', '~> 1.2', '>= 1.2.5'
+  s.add_development_dependency 'grpc', '~> 1.10', '>= 1.2.5'
   s.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'
 
   s.files = Dir["./lib/**/*.rb"]


### PR DESCRIPTION
Older versions of `google-protobuf` specifically depend on Ruby < 2.5:

  https://rubygems.org/gems/google-protobuf/versions/3.2.0-x86-linux

Newer versions lift that restriction.  If we want to use gcr with Ruby >
2.5, we need to update `google-protobuf`.  For some reason `grpc` also
had that restriction on Ruby.