### PR TITLE
Fix error message when stub is not set

### DIFF
--- a/lib/gcr.rb
+++ b/lib/gcr.rb
@@ -53,7 +53,7 @@ module GCR
   #
   # Returns a A GRPC::ClientStub instance. Raises ConfigError if not configured.
   def stub
-    @stub || (raise ConfigError, "no cassette dir configured")
+    @stub || (raise ConfigError, "no stub configured")
   end
 
   def insert(name)


### PR DESCRIPTION
Incorrect error message appears when stub is not set.